### PR TITLE
Allow comments after int values

### DIFF
--- a/resources/example.conf
+++ b/resources/example.conf
@@ -13,7 +13,7 @@ password = 123
 [supervisord]
 logfile = /tmp/supervisord.log
 logfile_maxbytes = 50MB
-logfile_backups=10
+logfile_backups=10 ;comment
 loglevel = info
 pidfile = /tmp/supervisord.pid
 nodaemon = false

--- a/src/Configuration/Parser/Base.php
+++ b/src/Configuration/Parser/Base.php
@@ -83,7 +83,7 @@ abstract class Base implements Parser
         $sections = [];
 
         foreach ($ini as $name => $section) {
-            $section = $this->parseSection($name, $section);
+            $section = $this->parseSection($name, array_map('trim', $section));
             $sections[] = $section;
         }
 


### PR DESCRIPTION
Space between a int value and a comment throws an exception when parsing existing config file.
